### PR TITLE
fix: rename init to active

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All plugins define:
 - `target` _String_: target field relative to the plugin path.
 - `required` _Array_: required fields relative to the plugin path. Can specify relative to root by prefixing with `/`. Will influence `fieldsToRequest`. Can be specified as function that takes `initContext` and expected to return array.
 - `fn` _Function_: result of this function is used by the plugin. Signature is `fn({ key, value, parents, context, cache })`.
-- `init({ context, cache })` _Function_ (optional): if present called once per run, if returns other than `true`, the plugin is disabled for the run
+- `active({ context, cache })` _Function_ (optional): if present called once per run, if returns other than `true`, the plugin is disabled for the run
 - `contextSchema`: Object schema structure of what is expected to be present in `context` (subset)
 - `valueSchema` (optional): Used to validate value before passed into `fn`
 

--- a/src/module/plugin.js
+++ b/src/module/plugin.js
@@ -15,14 +15,14 @@ const plugin = (type, options) => {
     ),
     contextSchema: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).optional(),
     valueSchema: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).optional(),
-    init: Joi.function().optional(),
+    active: Joi.function().optional(),
     fn: Joi.function(),
     fnSchema: type === 'INJECT' ? Joi.alternatives(Joi.object(), Joi.array(), Joi.function()) : Joi.forbidden(),
     limit: type === 'SORT' ? Joi.function().optional() : Joi.forbidden()
   }));
 
   const {
-    name, target, requires, contextSchema, valueSchema, init, fn, fnSchema, limit
+    name, target, requires, contextSchema, valueSchema, active, fn, fnSchema, limit
   } = options;
 
   const contextSchemaCompiled = contextSchema === undefined
@@ -110,7 +110,7 @@ const plugin = (type, options) => {
   self.meta = {
     name,
     contextSchema,
-    init: (context, logger) => {
+    active: (context, logger) => {
       if (contextSchemaCompiled(context) === false) {
         logger.warn(`Context validation failure\n${JSON.stringify({
           origin: 'object-rewrite',
@@ -126,7 +126,7 @@ const plugin = (type, options) => {
           return p;
         }, {})
         : context;
-      return init === undefined ? true : wrap(init)();
+      return active === undefined ? true : wrap(active)();
     }
   };
   return self;

--- a/src/module/rewriter/init-plugin-map.js
+++ b/src/module/rewriter/init-plugin-map.js
@@ -4,7 +4,7 @@ module.exports = (map, context, logger) => {
   Object.entries(map).forEach(([prefix, pls]) => {
     result[prefix] = pls.filter((pl) => {
       if (!plugins.has(pl.self)) {
-        plugins.set(pl.self, pl.self.meta.init(context, logger));
+        plugins.set(pl.self, pl.self.meta.active(context, logger));
       }
       return plugins.get(pl.self) === true;
     });

--- a/test/module/rewriter.spec.js
+++ b/test/module/rewriter.spec.js
@@ -554,7 +554,7 @@ describe('Testing rewriter', () => {
     expect(data).to.deep.equal([{ settings: { a: 2, b: 3 } }, { settings: { a: 1, b: 2 } }]);
   });
 
-  it('Testing init', async () => {
+  it('Testing active', async () => {
     const dataStoreFields = ['a'];
     const data = [{ a: 2 }, { a: 1 }];
     const fields = ['a'];
@@ -567,8 +567,8 @@ describe('Testing rewriter', () => {
       contextSchema: {
         enabled: (e) => typeof e === 'boolean'
       },
-      init: ({ context, cache }) => {
-        logs.push('init');
+      active: ({ context, cache }) => {
+        logs.push('active');
         logs.push(`context = ${context.a}`);
         context.a = (context.a || 0) + 3;
         logs.push(`cache = ${cache.a}`);
@@ -592,16 +592,16 @@ describe('Testing rewriter', () => {
 
     rew.rewrite(data, { enabled: false });
     expect(logs).to.deep.equal([
-      'init', 'context = undefined', 'cache = undefined',
-      'init', 'context = undefined', 'cache = undefined'
+      'active', 'context = undefined', 'cache = undefined',
+      'active', 'context = undefined', 'cache = undefined'
     ]);
     expect(data).to.deep.equal([{ a: 2 }, { a: 1 }]);
 
     logs.length = 0;
     rew.rewrite(data, { enabled: true });
     expect(logs).to.deep.equal([
-      'init', 'context = undefined', 'cache = undefined',
-      'init', 'context = undefined', 'cache = undefined',
+      'active', 'context = undefined', 'cache = undefined',
+      'active', 'context = undefined', 'cache = undefined',
       'value = 1', 'context = 3', 'cache = 5',
       'value = 9', 'context = 3', 'cache = 5',
       'value = 2', 'context = 3', 'cache = 5',
@@ -610,7 +610,7 @@ describe('Testing rewriter', () => {
     expect(data).to.deep.equal([{ a: 18 }, { a: 17 }]);
   });
 
-  it('Testing init executes once per plugin', async () => {
+  it('Testing active executes once per plugin', async () => {
     const dataStoreFields = ['a', 'b.a'];
     const data = [{ a: 2, b: { a: 3 } }, { a: 1, b: { a: 4 } }];
     const fields = ['a', 'b.a'];
@@ -620,8 +620,8 @@ describe('Testing rewriter', () => {
       target: 'a',
       fnSchema: (r) => Number.isInteger(r),
       requires: ['a'],
-      init: () => {
-        logs.push('init');
+      active: () => {
+        logs.push('active');
         return true;
       },
       fn: ({ value }) => value.a + 1
@@ -633,7 +633,7 @@ describe('Testing rewriter', () => {
     expect(rew.fieldsToRequest).to.deep.equal(['a', 'b.a']);
 
     rew.rewrite(data);
-    expect(logs).to.deep.equal(['init']);
+    expect(logs).to.deep.equal(['active']);
     expect(data).to.deep.equal([{ a: 4, b: { a: 4 } }, { a: 3, b: { a: 5 } }]);
   });
 
@@ -646,21 +646,21 @@ describe('Testing rewriter', () => {
       target: 'a',
       fnSchema: (r) => Number.isInteger(r),
       requires: ['a'],
-      init: () => false,
+      active: () => false,
       fn: () => 3
     });
     const p2 = filterPlugin({
       name: 'filter-plugin-name',
       target: 'a',
       requires: ['a'],
-      init: () => false,
+      active: () => false,
       fn: () => false
     });
     const p3 = sortPlugin({
       name: 'sort-plugin-name',
       target: 'a',
       requires: ['a'],
-      init: () => false,
+      active: () => false,
       fn: () => []
     });
     expect(p1('').fn()).to.deep.equal(3);


### PR DESCRIPTION
BREAKING CHANGE: plugin.init renamed to plugin.active