### PR TITLE
fix: split active into onInit and onRewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ All plugins define:
 - `target` _String_: target field relative to the plugin path.
 - `required` _Array_: required fields relative to the plugin path. Can specify relative to root by prefixing with `/`. Will influence `fieldsToRequest`. Can be specified as function that takes `initContext` and expected to return array.
 - `fn` _Function_: result of this function is used by the plugin. Signature is `fn({ key, value, parents, context, cache })`.
-- `active({ context, cache })` _Function_ (optional): if present called once per run, if returns other than `true`, the plugin is disabled for the run
+- `onInit({ context, cache })` _Function_ (optional): if present called once per init, used to initialize cache, if returns other than `true`, the plugin is disabled
+- `onRewrite({ data, context, cache })` _Function_ (optional): if present called once per rewrite, used to initialize cache, if returns other than `true`, the plugin is disabled
 - `contextSchema`: Object schema structure of what is expected to be present in `context` (subset)
 - `valueSchema` (optional): Used to validate value before passed into `fn`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ All plugins define:
 - `fn` _Function_: result of this function is used by the plugin. Signature is `fn({ key, value, parents, context, cache })`.
 - `onInit({ context, cache })` _Function_ (optional): if present called once per init, used to initialize cache, if returns other than `true`, the plugin is disabled
 - `onRewrite({ data, context, cache })` _Function_ (optional): if present called once per rewrite, used to update cache, if returns other than `true`, the plugin is disabled
-- `contextSchema`: Object schema structure of what is expected to be present in `context` (subset)
+- `contextSchema`: Object schema structure of what is expected to be present in rewrite `context` (subset)
 - `valueSchema` (optional): Used to validate value before passed into `fn`
 
 where:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ All plugins define:
 - `required` _Array_: required fields relative to the plugin path. Can specify relative to root by prefixing with `/`. Will influence `fieldsToRequest`. Can be specified as function that takes `initContext` and expected to return array.
 - `fn` _Function_: result of this function is used by the plugin. Signature is `fn({ key, value, parents, context, cache })`.
 - `onInit({ context, cache })` _Function_ (optional): if present called once per init, used to initialize cache, if returns other than `true`, the plugin is disabled
-- `onRewrite({ data, context, cache })` _Function_ (optional): if present called once per rewrite, used to initialize cache, if returns other than `true`, the plugin is disabled
+- `onRewrite({ data, context, cache })` _Function_ (optional): if present called once per rewrite, used to update cache, if returns other than `true`, the plugin is disabled
 - `contextSchema`: Object schema structure of what is expected to be present in `context` (subset)
 - `valueSchema` (optional): Used to validate value before passed into `fn`
 

--- a/src/module/plugin.js
+++ b/src/module/plugin.js
@@ -112,12 +112,12 @@ const plugin = (type, options) => {
     name,
     contextSchema,
     onInit: (initContext) => {
-      localCache = null;
-      localContext = null;
+      localCache = {};
+      localContext = initContext;
       if (onInit === undefined) {
         return true;
       }
-      return wrap(onInit)({ initContext });
+      return wrap(onInit)();
     },
     onRewrite: (data, context, logger) => {
       if (contextSchemaCompiled(context) === false) {
@@ -127,7 +127,6 @@ const plugin = (type, options) => {
         })}`);
         return false;
       }
-      localCache = {};
       localContext = contextSchema instanceof Object && !Array.isArray(contextSchema)
         ? Object.keys(contextSchema).reduce((p, k) => {
           // eslint-disable-next-line no-param-reassign

--- a/src/module/plugin.js
+++ b/src/module/plugin.js
@@ -15,14 +15,15 @@ const plugin = (type, options) => {
     ),
     contextSchema: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).optional(),
     valueSchema: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).optional(),
-    active: Joi.function().optional(),
+    onInit: Joi.function().optional(),
+    onRewrite: Joi.function().optional(),
     fn: Joi.function(),
     fnSchema: type === 'INJECT' ? Joi.alternatives(Joi.object(), Joi.array(), Joi.function()) : Joi.forbidden(),
     limit: type === 'SORT' ? Joi.function().optional() : Joi.forbidden()
   }));
 
   const {
-    name, target, requires, contextSchema, valueSchema, active, fn, fnSchema, limit
+    name, target, requires, contextSchema, valueSchema, onInit, onRewrite, fn, fnSchema, limit
   } = options;
 
   const contextSchemaCompiled = contextSchema === undefined
@@ -110,7 +111,15 @@ const plugin = (type, options) => {
   self.meta = {
     name,
     contextSchema,
-    active: (context, logger) => {
+    onInit: (initContext) => {
+      localCache = null;
+      localContext = null;
+      if (onInit === undefined) {
+        return true;
+      }
+      return wrap(onInit)({ initContext });
+    },
+    onRewrite: (data, context, logger) => {
       if (contextSchemaCompiled(context) === false) {
         logger.warn(`Context validation failure\n${JSON.stringify({
           origin: 'object-rewrite',
@@ -126,7 +135,7 @@ const plugin = (type, options) => {
           return p;
         }, {})
         : context;
-      return active === undefined ? true : wrap(active)();
+      return onRewrite === undefined ? true : wrap(onRewrite)();
     }
   };
   return self;

--- a/src/module/rewriter.js
+++ b/src/module/rewriter.js
@@ -54,17 +54,17 @@ module.exports = (pluginMap, dataStoreFields_, logger = console) => {
       const rewriteStart = (input, context) => {
         assert(context instanceof Object && !Array.isArray(context));
         const { promises } = injectRewriter(input, {
-          injectMap: initPluginMap(injectMap, context, logger),
+          injectMap: initPluginMap(injectMap, input, context, logger),
           promises: []
         });
         return promises;
       };
       const rewriteEnd = (input, context) => {
         filterRewriter(input, {
-          filterMap: initPluginMap(filterMap, context, logger)
+          filterMap: initPluginMap(filterMap, input, context, logger)
         });
         sortRewriter(input, {
-          sortMap: initPluginMap(sortMap, context, logger),
+          sortMap: initPluginMap(sortMap, input, context, logger),
           lookups: []
         });
         retainResult(input);
@@ -72,12 +72,14 @@ module.exports = (pluginMap, dataStoreFields_, logger = console) => {
       return {
         fieldsToRequest,
         activePlugins,
-        rewrite: (input, context = {}) => {
+        rewrite: (input, context_ = {}) => {
+          const context = { ...context_, ...initContext };
           const promises = rewriteStart(input, context);
           assert(promises.length === 0, 'Please use rewriteAsync() for async logic');
           rewriteEnd(input, context);
         },
-        rewriteAsync: async (input, context = {}) => {
+        rewriteAsync: async (input, context_ = {}) => {
+          const context = { ...context_, ...initContext };
           const promises = rewriteStart(input, context);
           await Promise.all(promises.map((p) => p()));
           rewriteEnd(input, context);

--- a/src/module/rewriter/compile-meta.js
+++ b/src/module/rewriter/compile-meta.js
@@ -8,6 +8,8 @@ module.exports = (plugins, fields, initContext) => {
     SORT: []
   };
 
+  const activeLookup = new Map();
+
   const activePlugins = new Set();
   const inactivePlugins = [...plugins];
   const requiredFields = [...new Set(fields)];
@@ -16,11 +18,17 @@ module.exports = (plugins, fields, initContext) => {
     const field = requiredFields[i];
     for (let j = 0; j < inactivePlugins.length; j += 1) {
       const plugin = inactivePlugins[j];
+      if (!activeLookup.has(plugin.self)) {
+        activeLookup.set(plugin.self, plugin.self.meta.onInit(initContext));
+      }
       if (
-        plugin.targets.includes(field)
-        || (
-          (plugin.type !== 'INJECT' || plugin.targetRel === '*')
-          && (`${field}.` === plugin.target || field.startsWith(plugin.target))
+        activeLookup.get(plugin.self) === true
+        && (
+          plugin.targets.includes(field)
+          || (
+            (plugin.type !== 'INJECT' || plugin.targetRel === '*')
+            && (`${field}.` === plugin.target || field.startsWith(plugin.target))
+          )
         )
       ) {
         const requires = [...plugin.requires(initContext)];

--- a/src/module/rewriter/init-plugin-map.js
+++ b/src/module/rewriter/init-plugin-map.js
@@ -1,12 +1,12 @@
-module.exports = (map, context, logger) => {
+module.exports = (map, data, context, logger) => {
   const result = {};
-  const plugins = new Map();
+  const activeLookup = new Map();
   Object.entries(map).forEach(([prefix, pls]) => {
     result[prefix] = pls.filter((pl) => {
-      if (!plugins.has(pl.self)) {
-        plugins.set(pl.self, pl.self.meta.active(context, logger));
+      if (!activeLookup.has(pl.self)) {
+        activeLookup.set(pl.self, pl.self.meta.onRewrite(data, context, logger));
       }
-      return plugins.get(pl.self) === true;
+      return activeLookup.get(pl.self) === true;
     });
   });
   return result;

--- a/test/module/rewriter.spec.js
+++ b/test/module/rewriter.spec.js
@@ -657,7 +657,7 @@ describe('Testing rewriter', () => {
       name: 'filter-plugin-name',
       target: 'a',
       requires: ['a'],
-      onRewrite: () => false,
+      onInit: () => false,
       fn: () => false
     });
     const p3 = sortPlugin({
@@ -674,6 +674,7 @@ describe('Testing rewriter', () => {
       '': [p1, p2, p3]
     }, dataStoreFields).init(fields);
     expect(rew.fieldsToRequest).to.deep.equal(['a']);
+    expect(rew.activePlugins).to.deep.equal([p1.meta, p3.meta]);
 
     rew.rewrite(data);
     expect(data).to.deep.equal([{ a: 2 }, { a: 1 }]);

--- a/test/module/rewriter.spec.js
+++ b/test/module/rewriter.spec.js
@@ -554,7 +554,7 @@ describe('Testing rewriter', () => {
     expect(data).to.deep.equal([{ settings: { a: 2, b: 3 } }, { settings: { a: 1, b: 2 } }]);
   });
 
-  it('Testing active', async () => {
+  it('Testing onRewrite', async () => {
     const dataStoreFields = ['a'];
     const data = [{ a: 2 }, { a: 1 }];
     const fields = ['a'];
@@ -567,8 +567,8 @@ describe('Testing rewriter', () => {
       contextSchema: {
         enabled: (e) => typeof e === 'boolean'
       },
-      active: ({ context, cache }) => {
-        logs.push('active');
+      onRewrite: ({ context, cache }) => {
+        logs.push('onRewrite');
         logs.push(`context = ${context.a}`);
         context.a = (context.a || 0) + 3;
         logs.push(`cache = ${cache.a}`);
@@ -592,16 +592,16 @@ describe('Testing rewriter', () => {
 
     rew.rewrite(data, { enabled: false });
     expect(logs).to.deep.equal([
-      'active', 'context = undefined', 'cache = undefined',
-      'active', 'context = undefined', 'cache = undefined'
+      'onRewrite', 'context = undefined', 'cache = undefined',
+      'onRewrite', 'context = undefined', 'cache = undefined'
     ]);
     expect(data).to.deep.equal([{ a: 2 }, { a: 1 }]);
 
     logs.length = 0;
     rew.rewrite(data, { enabled: true });
     expect(logs).to.deep.equal([
-      'active', 'context = undefined', 'cache = undefined',
-      'active', 'context = undefined', 'cache = undefined',
+      'onRewrite', 'context = undefined', 'cache = undefined',
+      'onRewrite', 'context = undefined', 'cache = undefined',
       'value = 1', 'context = 3', 'cache = 5',
       'value = 9', 'context = 3', 'cache = 5',
       'value = 2', 'context = 3', 'cache = 5',
@@ -610,7 +610,7 @@ describe('Testing rewriter', () => {
     expect(data).to.deep.equal([{ a: 18 }, { a: 17 }]);
   });
 
-  it('Testing active executes once per plugin', async () => {
+  it('Testing onInit and onRewrite executes once per plugin', async () => {
     const dataStoreFields = ['a', 'b.a'];
     const data = [{ a: 2, b: { a: 3 } }, { a: 1, b: { a: 4 } }];
     const fields = ['a', 'b.a'];
@@ -620,8 +620,12 @@ describe('Testing rewriter', () => {
       target: 'a',
       fnSchema: (r) => Number.isInteger(r),
       requires: ['a'],
-      active: () => {
-        logs.push('active');
+      onInit: () => {
+        logs.push('onInit');
+        return true;
+      },
+      onRewrite: () => {
+        logs.push('onRewrite');
         return true;
       },
       fn: ({ value }) => value.a + 1
@@ -633,7 +637,7 @@ describe('Testing rewriter', () => {
     expect(rew.fieldsToRequest).to.deep.equal(['a', 'b.a']);
 
     rew.rewrite(data);
-    expect(logs).to.deep.equal(['active']);
+    expect(logs).to.deep.equal(['onInit', 'onRewrite']);
     expect(data).to.deep.equal([{ a: 4, b: { a: 4 } }, { a: 3, b: { a: 5 } }]);
   });
 
@@ -646,21 +650,21 @@ describe('Testing rewriter', () => {
       target: 'a',
       fnSchema: (r) => Number.isInteger(r),
       requires: ['a'],
-      active: () => false,
+      onRewrite: () => false,
       fn: () => 3
     });
     const p2 = filterPlugin({
       name: 'filter-plugin-name',
       target: 'a',
       requires: ['a'],
-      active: () => false,
+      onRewrite: () => false,
       fn: () => false
     });
     const p3 = sortPlugin({
       name: 'sort-plugin-name',
       target: 'a',
       requires: ['a'],
-      active: () => false,
+      onRewrite: () => false,
       fn: () => []
     });
     expect(p1('').fn()).to.deep.equal(3);

--- a/test/module/rewriter.spec.js
+++ b/test/module/rewriter.spec.js
@@ -600,14 +600,14 @@ describe('Testing rewriter', () => {
     logs.length = 0;
     rew.rewrite(data, { enabled: true });
     expect(logs).to.deep.equal([
-      'onRewrite', 'context = undefined', 'cache = undefined',
-      'onRewrite', 'context = undefined', 'cache = undefined',
-      'value = 1', 'context = 3', 'cache = 5',
-      'value = 9', 'context = 3', 'cache = 5',
-      'value = 2', 'context = 3', 'cache = 5',
-      'value = 10', 'context = 3', 'cache = 5'
+      'onRewrite', 'context = undefined', 'cache = 5',
+      'onRewrite', 'context = undefined', 'cache = 5',
+      'value = 1', 'context = 3', 'cache = 10',
+      'value = 14', 'context = 3', 'cache = 10',
+      'value = 2', 'context = 3', 'cache = 10',
+      'value = 15', 'context = 3', 'cache = 10'
     ]);
-    expect(data).to.deep.equal([{ a: 18 }, { a: 17 }]);
+    expect(data).to.deep.equal([{ a: 28 }, { a: 27 }]);
   });
 
   it('Testing onInit and onRewrite executes once per plugin', async () => {


### PR DESCRIPTION
BREAKING CHANGE: plugin.active renamed to plugin.onRewrite